### PR TITLE
fix multiply and alpha blend

### DIFF
--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Blend.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Blend.java
@@ -42,7 +42,7 @@ public class Blend {
                 };
                 case "multiply" -> blendFunc = () -> {
                     RenderSystem.blendFunc(GlStateManager.SrcFactor.DST_COLOR, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA);
-                    RenderSystem.blendEquation(Equation.ADD.value);
+                    RenderSystem.blendEquation(Equation.SUBTRACT.value);
                 };
                 case "screen" -> blendFunc = () -> {
                     RenderSystem.blendFunc(GlStateManager.SrcFactor.ONE, GlStateManager.DstFactor.ONE_MINUS_SRC_COLOR);
@@ -53,7 +53,7 @@ public class Blend {
                     RenderSystem.blendEquation(Equation.ADD.value);
                 };
                 case "alpha" -> blendFunc = () -> {
-                    RenderSystem.blendFunc(GlStateManager.SrcFactor.DST_ALPHA, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA);
+                    RenderSystem.blendFunc(GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA);
                     RenderSystem.blendEquation(Equation.ADD.value);
                 };
                 case "burn" -> blendFunc = () -> {


### PR DESCRIPTION
Fixes some stuff, it didn't work properly before  

also for dodge and burn, you may need to manually run a calculation on each pixel instead of using an opengl blend (if possible)
reference: https://en.wikipedia.org/wiki/Blend_modes#Dodge_and_burn